### PR TITLE
Quick fix so plugin compiles in minecarft 1.12

### DIFF
--- a/src/main/java/com/mtihc/minecraft/myhelppages/util/YamlFile.java
+++ b/src/main/java/com/mtihc/minecraft/myhelppages/util/YamlFile.java
@@ -78,10 +78,10 @@ public class YamlFile {
 	 */
 	public void setDefaults(String fileName) {
 		
-		InputStream defConfigStream = plugin.getResource(fileName + ".yml");
-		if (defConfigStream != null) {
+		Reader reader = new InputStreamReader(plugin.getResource(fileName + ".yml"));
+		if (reader != null) {
 			YamlConfiguration defConfig = YamlConfiguration
-				.loadConfiguration(defConfigStream);
+				.loadConfiguration(reader);
 			config.options().copyDefaults(true);
 			config.setDefaults(defConfig);
 			save();
@@ -96,10 +96,10 @@ public class YamlFile {
 	 */
 	public void addDefaults(String fileName) {
 		
-		InputStream defConfigStream = plugin.getResource(fileName + ".yml");
-		if (defConfigStream != null) {
+		Reader reader = new InputStreamReader(plugin.getResource(fileName + ".yml"));
+		if (reader != null) {
 			YamlConfiguration defConfig = YamlConfiguration
-				.loadConfiguration(defConfigStream);
+				.loadConfiguration(reader);
 			config.options().copyDefaults(true);
 			config.addDefaults(defConfig);
 			save();


### PR DESCRIPTION
Quick fix so the plugin will compile and run with minecarft 1.12

`YamlConfiguration.loadConfiguration(inputStream)` no longer accepts an input stream, and must be either a Reader or a File.

Tested with this fix in 1.12 and it works perfectly.